### PR TITLE
Annotation Warning No Longer Appears

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -130,7 +130,13 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
-
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <configuration>
+                    <compilerArgument>-proc:full</compilerArgument>
+                    </configuration>
+                </plugin>
             <!-- Test case coverage report -->
             <plugin>
                 <groupId>org.jacoco</groupId>


### PR DESCRIPTION
Closes #8 

Added plugin to pom.xml that suppresses the waring about annotations.