### PR TITLE
User-friendly error message to adding 2 sections of same course

### DIFF
--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -63,8 +63,8 @@ export function useBackendMutation(
   const queryClient = useQueryClient();
 
   return useMutation((object) => wrappedParams(objectToAxiosParams(object)), {
-    onError: (error) => {
-      const errorMessage = `useBackendMutation: Error communicating with backend via ${error.response.config.method} on ${error.response.config.url}`;
+    onError: (_error) => {
+      const errorMessage = `You already have a section of this course on your personal schedule; to add this one instead, drop the other one first`;
       toast(errorMessage, { type: "error" });
     },
     // Stryker disable all : Not sure how to set up the complex behavior needed to test this

--- a/frontend/src/tests/utils/useBackendMutationFailure.test.js
+++ b/frontend/src/tests/utils/useBackendMutationFailure.test.js
@@ -86,7 +86,7 @@ describe("utils/useBackend tests", () => {
       );
 
       const messageA =
-        "useBackendMutation: Error communicating with backend via post on /api/ucsbdates/post";
+        "You already have a section of this course on your personal schedule; to add this one instead, drop the other one first";
       const messageB = "onError from mutation.mutate called!";
       const messageC = "Error: Request failed with status code 404";
 


### PR DESCRIPTION
Closes #2 
Properly updates error message on local to user-friendly text
Test by: create a personal schedule, add a class, add another section in same class

Local host view:
<img width="1726" alt="Screenshot 2024-11-18 at 2 48 43 PM" src="https://github.com/user-attachments/assets/a945967d-589c-4abf-a218-0914dd738bed">

New Error message:
<img width="314" alt="Screenshot 2024-11-18 at 2 48 54 PM" src="https://github.com/user-attachments/assets/727b41be-8c21-4d43-abff-8c682d5f3ffa">