### PR TITLE
Description optional on personal schedule - UPDATED

### DIFF
--- a/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
+++ b/frontend/src/main/components/PersonalSchedules/PersonalScheduleForm.js
@@ -84,16 +84,8 @@ function PersonalScheduleForm({
           data-testid="PersonalScheduleForm-description"
           id="description"
           type="text"
-          // Made description optional
-          /* isInvalid={Boolean(errors.description)}
-          {...register("description", {
-            required: "Description is required.",
-          })} */
           {...register("description")}
         />
-        {/* <Form.Control.Feedback type="invalid">
-          {errors.description?.message}
-        </Form.Control.Feedback> */}
       </Form.Group>
       {initialPersonalSchedule ? (
         <Form.Group className="mb-3">

--- a/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
+++ b/frontend/src/tests/components/PersonalSchedules/PersonalScheduleForm.test.js
@@ -81,8 +81,6 @@ describe("PersonalScheduleForm tests", () => {
     fireEvent.click(submitButton);
 
     expect(await screen.findByText(/Name is required./)).toBeInTheDocument();
-    // Made description optional
-    // expect(screen.getByText(/Description is required./)).toBeInTheDocument();
   });
 
   test("No Error messages on good input", async () => {


### PR DESCRIPTION
Same as my previous PR, the description field on personal schedule is now optional. Updated so there's no more commented out code.

Before (description was required):
<img width="1339" alt="Screenshot 2024-11-19 at 5 49 25 PM" src="https://github.com/user-attachments/assets/14fed592-b0c2-4e98-b2cf-764ec1f1aa96">

After (can submit personal schedule with no problem):
<img width="1140" alt="Screenshot 2024-11-19 at 5 48 17 PM" src="https://github.com/user-attachments/assets/ff070c60-44a5-4aaf-8006-ebdbe49ad087">
<img width="1337" alt="Screenshot 2024-11-20 at 11 42 48 PM" src="https://github.com/user-attachments/assets/cadee203-4f7a-4314-99c2-85b76f9ee40d">


Dokku link: https://courses-qwaszxjack.dokku-04.cs.ucsb.edu/

Closes #4 

