### PR TITLE
nk - User friendly error message from 2 sections of same course (UPDATED)

### DIFF
--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -120,9 +120,7 @@ export const onSuccess = (response) => {
 };
 
 const onError = (error) => {
-  toast(
-    `Error: ${error.response.data.message}`,
-  );
+  toast(`Error: ${error.response.data.message}`);
 };
 
 export default function SectionsTable({ sections }) {

--- a/frontend/src/main/components/Sections/SectionsTable.js
+++ b/frontend/src/main/components/Sections/SectionsTable.js
@@ -119,6 +119,12 @@ export const onSuccess = (response) => {
   );
 };
 
+const onError = (error) => {
+  toast(
+    `Error: ${error.response.data.message}`,
+  );
+};
+
 export default function SectionsTable({ sections }) {
   // Stryker restore all
   // Stryker disable BooleanLiteral
@@ -126,7 +132,7 @@ export default function SectionsTable({ sections }) {
 
   const mutation = useBackendMutation(
     objectToAxiosParams,
-    { onSuccess },
+    { onSuccess, onError },
     // Stryker disable next-line all : hard to set up test for caching
     ["/api/courses/user/all"],
   );

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -426,6 +426,37 @@ describe("Section tests", () => {
     );
   });
 
+  test("calls onError when mutation is not successful and calls toast with correct parameters", () => {
+    const mockMutate = jest.fn();
+    const mockMutation = { mutate: mockMutate };
+
+    useBackendMutation.mockReturnValue(mockMutation);
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    // Call the onError function
+    const onError = useBackendMutation.mock.calls[0][1].onError;
+    const mockResponse = {
+      response: {
+        data: {
+          message: "You already have a section of this course on your personal schedule; to add this one instead, drop the other one first."
+        }
+      }
+    };
+    onError(mockResponse);
+
+    // Verify that toast was called with the correct parameters
+    expect(toast).toHaveBeenCalledWith(
+      "Error: You already have a section of this course on your personal schedule; to add this one instead, drop the other one first.",
+    );
+  });
+
   test("renders without crashing for empty table", () => {
     render(
       <QueryClientProvider client={queryClient}>

--- a/frontend/src/tests/components/Sections/SectionsTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsTable.test.js
@@ -445,9 +445,10 @@ describe("Section tests", () => {
     const mockResponse = {
       response: {
         data: {
-          message: "You already have a section of this course on your personal schedule; to add this one instead, drop the other one first."
-        }
-      }
+          message:
+            "You already have a section of this course on your personal schedule; to add this one instead, drop the other one first.",
+        },
+      },
     };
     onError(mockResponse);
 

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
@@ -143,7 +143,7 @@ public class PSCourseController extends ApiController {
     }
 
     if (coursesRepository.findByPsIdAndEnrollCd(psId, enrollCdPrimary).isPresent()) {
-      throw new IllegalArgumentException("class exists in schedule");
+      throw new IllegalArgumentException("You already have a section of this course on your personal schedule; to add this one instead, drop the other one first.");
     }
 
     ArrayList<PSCourse> savedCourses = new ArrayList<>();

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/PSCourseController.java
@@ -143,7 +143,8 @@ public class PSCourseController extends ApiController {
     }
 
     if (coursesRepository.findByPsIdAndEnrollCd(psId, enrollCdPrimary).isPresent()) {
-      throw new IllegalArgumentException("You already have a section of this course on your personal schedule; to add this one instead, drop the other one first.");
+      throw new IllegalArgumentException(
+          "You already have a section of this course on your personal schedule; to add this one instead, drop the other one first.");
     }
 
     ArrayList<PSCourse> savedCourses = new ArrayList<>();

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
@@ -410,7 +410,7 @@ public class PSCourseControllerTests extends ControllerTestCase {
 
     // assert
     Map<String, Object> json = responseToJson(response);
-    assertEquals("class exists in schedule", json.get("message"));
+    assertEquals("You already have a section of this course on your personal schedule; to add this one instead, drop the other one first.", json.get("message"));
     assertEquals("IllegalArgumentException", json.get("type"));
   }
 

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/PSCourseControllerTests.java
@@ -410,7 +410,9 @@ public class PSCourseControllerTests extends ControllerTestCase {
 
     // assert
     Map<String, Object> json = responseToJson(response);
-    assertEquals("You already have a section of this course on your personal schedule; to add this one instead, drop the other one first.", json.get("message"));
+    assertEquals(
+        "You already have a section of this course on your personal schedule; to add this one instead, drop the other one first.",
+        json.get("message"));
     assertEquals("IllegalArgumentException", json.get("type"));
   }
 


### PR DESCRIPTION
Closes #2 

New error message informs user to drop a previous section before adding a new section in the same course. In comparison to old message which informed user of an error in "/api/courses/post"

Dokku link: https://proj-courses-nilay-kundu.dokku-04.cs.ucsb.edu

Old message: 
<img width="340" alt="Screenshot 2024-11-19 at 10 24 52 PM" src="https://github.com/user-attachments/assets/7a868fb9-4f52-465b-94b4-f7c3c28a48a8">

New message:
<img width="319" alt="Screenshot 2024-11-19 at 10 25 37 PM" src="https://github.com/user-attachments/assets/2e31bd1a-d4fe-4b17-9aa5-04c483572084">

New message (full screen context):
<img width="1434" alt="Screenshot 2024-11-19 at 10 26 10 PM" src="https://github.com/user-attachments/assets/d46b79c2-460a-4d9f-a271-fb89b9028ed3">
