### PR TITLE
nk Updates Page only accessible to Admins

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import CourseDescriptionIndexPage from "main/pages/CourseDescriptions/CourseDescriptionIndexPage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/Admin/AdminUsersPage";
+import AdminUpdatesPage from "main/pages/Admin/AdminUpdatesPage";
 import AdminLoadSubjectsPage from "main/pages/Admin/AdminLoadSubjectsPage";
 import AdminJobsPage from "main/pages/Admin/AdminJobsPage";
 import DeveloperPage from "main/pages/DeveloperPage"; // route from /developer to DeveloperPage
@@ -39,6 +40,7 @@ function App() {
               path="/admin/loadsubjects"
               element={<AdminLoadSubjectsPage />}
             />
+            <Route exact path="/admin/updates" element={<AdminUpdatesPage />} />
             <Route path="/admin/jobs" element={<AdminJobsPage />} />
             <Route path="/developer" element={<DeveloperPage />} />
           </>

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -115,6 +115,12 @@ export default function AppNavbar({
                     Users
                   </NavDropdown.Item>
                   <NavDropdown.Item
+                    href="/admin/updates"
+                    data-testid="appnavbar-admin-updates"
+                  >
+                    Updates
+                  </NavDropdown.Item>
+                  <NavDropdown.Item
                     href="/admin/personalschedule"
                     data-testid="appnavbar-admin-personalschedule"
                   >

--- a/frontend/src/main/pages/Admin/AdminUpdatesPage.js
+++ b/frontend/src/main/pages/Admin/AdminUpdatesPage.js
@@ -1,0 +1,12 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function AdminUpdatesPage() {
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Updates page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  );
+}

--- a/frontend/src/tests/pages/AdminUpdatesPage.test.js
+++ b/frontend/src/tests/pages/AdminUpdatesPage.test.js
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import AdminUpdatesPage from "main/pages/Admin/AdminUpdatesPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("AdminUpdatesPage tests", () => {
+  const axiosMock = new AxiosMockAdapter(axios);
+
+  const setupUserOnly = () => {
+    axiosMock.reset();
+    axiosMock.resetHistory();
+    axiosMock
+      .onGet("/api/currentUser")
+      .reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock
+      .onGet("/api/systemInfo")
+      .reply(200, systemInfoFixtures.showingNeither);
+  };
+
+  const queryClient = new QueryClient();
+  test("Renders expected content", async () => {
+    // arrange
+
+    setupUserOnly();
+
+    // act
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <AdminUpdatesPage />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    await screen.findByText("Updates page not yet implemented");
+
+    // assert
+    expect(
+      screen.getByText("Updates page not yet implemented"),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #16 

When logged in and an admin, user can access an "Updates" page from the Admin dropdown. Table component will be implemented in next issue.

Dokku link: https://proj-courses-nilay-kundu.dokku-04.cs.ucsb.edu

Dropdown menu:
<img width="580" alt="Screenshot 2024-11-24 at 12 07 53 PM" src="https://github.com/user-attachments/assets/3fb87738-0208-4a88-962f-3083b73caad6">

Updates page:
<img width="1728" alt="Screenshot 2024-11-24 at 12 08 01 PM" src="https://github.com/user-attachments/assets/d00e46ab-1859-4a53-aa82-9fa547979482">
