### PR TITLE
Test Added to Fix Stryker Exception on Arrow Function

### DIFF
--- a/frontend/src/main/components/Sections/SectionsOverTimeTable.js
+++ b/frontend/src/main/components/Sections/SectionsOverTimeTable.js
@@ -41,7 +41,6 @@ export default function SectionsOverTimeTable({ sections }) {
       aggregate: getCourseId,
       Aggregated: ({ cell: { value } }) => `${value}`,
 
-      // Stryker disable next-line ArrowFunction: factor out and test the arrow function separately
       Cell: ({ cell: { value } }) => value.substring(0, value.length - 2),
     },
     {

--- a/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
+++ b/frontend/src/tests/components/Sections/SectionsOverTimeTable.test.js
@@ -237,6 +237,30 @@ describe("Section tests", () => {
     ).toHaveTextContent("21/21");
   });
 
+  test("Dropdown has correct courseID", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <SectionsOverTimeTable sections={fiveSections} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const testId = "SectionsOverTimeTable";
+
+    const expandRow = screen.getByTestId(
+      `${testId}-cell-row-1-col-quarter-expand-symbols`,
+    );
+    fireEvent.click(expandRow);
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-1-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-2-col-courseInfo.courseId`),
+    ).toHaveTextContent("ECE 5");
+  });
+
   test("Status utility identifies each type of status", () => {
     render(
       <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
This PR adds a test for SectionsOverTimeTable to address the following mutation previously omitted by a stryker disable comment.

![Screenshot 2024-11-25 at 3 40 52 PM](https://github.com/user-attachments/assets/7df8de27-46f4-463b-a78e-e2fa12a1dd26)

The mutant in question would cause the courseID for individual sections to appear as empty strings. The added test checks the courseID column in the header and first section of the table to make sure they are correct.

<img width="1349" alt="Screenshot 2024-11-25 at 3 39 42 PM" src="https://github.com/user-attachments/assets/e600896a-fd2f-4a93-8817-27caee0c301d">

Closes #26 