### PR TITLE
Alvin - GET Endpoint - by job id

### DIFF
--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -15,16 +15,16 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.server.ResponseStatusException;
-import org.springframework.http.HttpStatus;
 
 @Tag(name = "Jobs")
 @RequestMapping("/api/jobs")
@@ -183,11 +183,12 @@ public class JobsController extends ApiController {
   @PreAuthorize("hasRole('ROLE_ADMIN')")
   @GetMapping("/logs/{jobId}")
   public Map<String, String> getJobLog(@Parameter(name = "jobId") @PathVariable Long jobId) {
-      Job job = jobsRepository.findById(jobId)
-              .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Job not found"));
+    Job job =
+        jobsRepository
+            .findById(jobId)
+            .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Job not found"));
 
-      // Assuming 'getLog' method returns the log output as a string
-      return Map.of("log", job.getLog());
+    // Assuming 'getLog' method returns the log output as a string
+    return Map.of("log", job.getLog());
   }
-  
 }

--- a/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
+++ b/src/main/java/edu/ucsb/cs156/courses/controllers/JobsController.java
@@ -22,6 +22,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
 
 @Tag(name = "Jobs")
 @RequestMapping("/api/jobs")
@@ -175,4 +178,16 @@ public class JobsController extends ApiController {
     UploadGradeDataJob updateGradeDataJob = updateGradeDataJobFactory.create();
     return jobService.runAsJob(updateGradeDataJob);
   }
+
+  @Operation(summary = "Get job logs")
+  @PreAuthorize("hasRole('ROLE_ADMIN')")
+  @GetMapping("/logs/{jobId}")
+  public Map<String, String> getJobLog(@Parameter(name = "jobId") @PathVariable Long jobId) {
+      Job job = jobsRepository.findById(jobId)
+              .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Job not found"));
+
+      // Assuming 'getLog' method returns the log output as a string
+      return Map.of("log", job.getLog());
+  }
+  
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -28,6 +28,7 @@ import edu.ucsb.cs156.courses.services.jobs.JobService;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Map;
+import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,7 +38,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
-import java.util.Optional;
 
 @Slf4j
 @WebMvcTest(controllers = JobsController.class)
@@ -355,27 +355,35 @@ public class JobsControllerTests extends ControllerTestCase {
 
     assertNotNull(jobReturned.getStatus());
   }
+
   @WithMockUser(roles = {"ADMIN"})
   @Test
   public void admin_can_query_job_by_id() throws Exception {
     // Arrange
-    Job job1 = Job.builder()
-                .id(1L) // Make sure the job has an ID
-                .log("this is job 1")
-                .build();
+    Job job1 =
+        Job.builder()
+            .id(1L) // Make sure the job has an ID
+            .log("this is job 1")
+            .build();
 
-    when(jobsRepository.findById(1L)).thenReturn(Optional.of(job1)); // Ensure you're using Optional for findById
+    when(jobsRepository.findById(1L))
+        .thenReturn(Optional.of(job1)); // Ensure you're using Optional for findById
 
     // Act
-    MvcResult response = mockMvc.perform(get("/api/jobs/logs/{jobId}", 1L)) // Use the correct URL with the job ID
-                              .andExpect(status().isOk())
-                              .andReturn();
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/jobs/logs/{jobId}", 1L)) // Use the correct URL with the job ID
+            .andExpect(status().isOk())
+            .andReturn();
 
     // Assert
-    verify(jobsRepository, times(1)).findById(1L); // Verify that findById(1L) was called, not findAll
-    String expectedJson = mapper.writeValueAsString(Map.of("log", "this is job 1")); // Expected response
+    verify(jobsRepository, times(1))
+        .findById(1L); // Verify that findById(1L) was called, not findAll
+    String expectedJson =
+        mapper.writeValueAsString(Map.of("log", "this is job 1")); // Expected response
     String responseString = response.getResponse().getContentAsString();
-    assertEquals(expectedJson, responseString); // Compare the response with the expected log content
+    assertEquals(
+        expectedJson, responseString); // Compare the response with the expected log content
   }
 
   @WithMockUser(roles = {"ADMIN"})
@@ -388,13 +396,18 @@ public class JobsControllerTests extends ControllerTestCase {
     when(jobsRepository.findById(nonexistentJobId)).thenReturn(Optional.empty());
 
     // Act
-    MvcResult response = mockMvc.perform(get("/api/jobs/logs/{jobId}", nonexistentJobId))
-                              .andExpect(status().isNotFound()) // Expect 404 Not Found status
-                              .andReturn();
+    MvcResult response =
+        mockMvc
+            .perform(get("/api/jobs/logs/{jobId}", nonexistentJobId))
+            .andExpect(status().isNotFound()) // Expect 404 Not Found status
+            .andReturn();
 
     // Assert
-    verify(jobsRepository, times(1)).findById(nonexistentJobId); // Verify findById was called once with the nonexistent job ID
+    verify(jobsRepository, times(1))
+        .findById(nonexistentJobId); // Verify findById was called once with the nonexistent job ID
     String responseString = response.getResponse().getContentAsString();
-    assertNotNull(responseString.contains("Job not found")); // Check that the response contains an error message
+    assertNotNull(
+        responseString.contains(
+            "Job not found")); // Check that the response contains an error message
   }
 }

--- a/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/courses/controllers/JobsControllerTests.java
@@ -37,6 +37,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
+import java.util.Optional;
 
 @Slf4j
 @WebMvcTest(controllers = JobsController.class)
@@ -353,5 +354,47 @@ public class JobsControllerTests extends ControllerTestCase {
     Job jobReturned = objectMapper.readValue(responseString, Job.class);
 
     assertNotNull(jobReturned.getStatus());
+  }
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_can_query_job_by_id() throws Exception {
+    // Arrange
+    Job job1 = Job.builder()
+                .id(1L) // Make sure the job has an ID
+                .log("this is job 1")
+                .build();
+
+    when(jobsRepository.findById(1L)).thenReturn(Optional.of(job1)); // Ensure you're using Optional for findById
+
+    // Act
+    MvcResult response = mockMvc.perform(get("/api/jobs/logs/{jobId}", 1L)) // Use the correct URL with the job ID
+                              .andExpect(status().isOk())
+                              .andReturn();
+
+    // Assert
+    verify(jobsRepository, times(1)).findById(1L); // Verify that findById(1L) was called, not findAll
+    String expectedJson = mapper.writeValueAsString(Map.of("log", "this is job 1")); // Expected response
+    String responseString = response.getResponse().getContentAsString();
+    assertEquals(expectedJson, responseString); // Compare the response with the expected log content
+  }
+
+  @WithMockUser(roles = {"ADMIN"})
+  @Test
+  public void admin_cannot_query_nonexistent_job_id() throws Exception {
+    // Arrange
+    long nonexistentJobId = 999L; // This job ID does not exist in the repository
+
+    // Mock the repository call to return an empty Optional, simulating a nonexistent job
+    when(jobsRepository.findById(nonexistentJobId)).thenReturn(Optional.empty());
+
+    // Act
+    MvcResult response = mockMvc.perform(get("/api/jobs/logs/{jobId}", nonexistentJobId))
+                              .andExpect(status().isNotFound()) // Expect 404 Not Found status
+                              .andReturn();
+
+    // Assert
+    verify(jobsRepository, times(1)).findById(nonexistentJobId); // Verify findById was called once with the nonexistent job ID
+    String responseString = response.getResponse().getContentAsString();
+    assertNotNull(responseString.contains("Job not found")); // Check that the response contains an error message
   }
 }


### PR DESCRIPTION
Closes #45 
Added tests - 1. check if log is properly queried, 2. throw error if job not found
<img width="1439" alt="Screenshot 2024-11-26 at 3 02 33 AM" src="https://github.com/user-attachments/assets/45eb0179-820d-43cd-a1fe-f0c7fd790519">
<img width="1409" alt="Screenshot 2024-11-26 at 3 02 40 AM" src="https://github.com/user-attachments/assets/fb564e3f-2660-4c28-b20d-930c50a37d85">

Test Deployment here (Reused old dokku deployment because newly created ones had DNS errors)
https://jpa03-alvinwang1.dokku-04.cs.ucsb.edu
