### PR TITLE
Finals info frontend table

### DIFF
--- a/frontend/src/fixtures/finalsInfoFixtures.js
+++ b/frontend/src/fixtures/finalsInfoFixtures.js
@@ -2,10 +2,10 @@ const finalsInfoFixtures = {
   oneFinalsInfo: {
     hasFinals: true,
     comments: "Final exam will be cumulative.",
-    examDay: "R", 
-    examDate: "2022-06-09", 
-    beginTime: "08:00", 
-    endTime: "11:00", 
+    examDay: "R",
+    examDate: "2022-06-09",
+    beginTime: "08:00",
+    endTime: "11:00",
   },
 };
 

--- a/frontend/src/fixtures/finalsInfoFixtures.js
+++ b/frontend/src/fixtures/finalsInfoFixtures.js
@@ -1,0 +1,12 @@
+const finalsInfoFixtures = {
+  oneFinalsInfo: {
+    hasFinals: true,
+    comments: "Final exam will be cumulative.",
+    examDay: "R", 
+    examDate: "2022-06-09", 
+    beginTime: "08:00", 
+    endTime: "11:00", 
+  },
+};
+
+export { finalsInfoFixtures };

--- a/frontend/src/main/components/CourseDetails/FinalsInfoDisplay.js
+++ b/frontend/src/main/components/CourseDetails/FinalsInfoDisplay.js
@@ -1,0 +1,38 @@
+import React from "react";
+import OurTable from "main/components/OurTable";
+
+export default function FinalsInfoDisplay({ finalsInfo }) {
+  const columns = [
+    {
+      Header: "Has Finals?",
+      accessor: "hasFinals",
+      Cell: ({ value }) => (value ? "Yes" : "No"), // boolean to readable text
+    },
+    {
+      Header: "Comments",
+      accessor: "comments",
+    },
+    {
+      Header: "Exam Day",
+      accessor: "examDay",
+    },
+    {
+      Header: "Exam Date",
+      accessor: "examDate",
+    },
+    {
+      Header: "Begin Time",
+      accessor: "beginTime",
+    },
+    {
+      Header: "End Time",
+      accessor: "endTime",
+    },
+  ];
+
+  const testid = "FinalsInfoDisplay";
+
+  const columnsToDisplay = columns;
+
+  return <OurTable data={finalsInfo} columns={columnsToDisplay} testid={testid} />;
+}

--- a/frontend/src/main/components/CourseDetails/FinalsInfoDisplay.js
+++ b/frontend/src/main/components/CourseDetails/FinalsInfoDisplay.js
@@ -2,6 +2,11 @@ import React from "react";
 import OurTable from "main/components/OurTable";
 
 export default function FinalsInfoDisplay({ finalsInfo }) {
+const formatDate = (dateString) => {
+    if (!dateString || dateString.length !== 8) return dateString; // Return original if not valid
+    return `${dateString.slice(0, 4)}-${dateString.slice(4, 6)}-${dateString.slice(6, 8)}`;
+    };
+
   const columns = [
     {
       Header: "Has Finals?",
@@ -19,6 +24,7 @@ export default function FinalsInfoDisplay({ finalsInfo }) {
     {
       Header: "Exam Date",
       accessor: "examDate",
+      Cell: ({ value }) => formatDate(value),
     },
     {
       Header: "Begin Time",

--- a/frontend/src/main/components/CourseDetails/FinalsInfoDisplay.js
+++ b/frontend/src/main/components/CourseDetails/FinalsInfoDisplay.js
@@ -2,10 +2,10 @@ import React from "react";
 import OurTable from "main/components/OurTable";
 
 export default function FinalsInfoDisplay({ finalsInfo }) {
-const formatDate = (dateString) => {
+  const formatDate = (dateString) => {
     if (!dateString || dateString.length !== 8) return dateString; // Return original if not valid
     return `${dateString.slice(0, 4)}-${dateString.slice(4, 6)}-${dateString.slice(6, 8)}`;
-    };
+  };
 
   const columns = [
     {
@@ -40,5 +40,7 @@ const formatDate = (dateString) => {
 
   const columnsToDisplay = columns;
 
-  return <OurTable data={finalsInfo} columns={columnsToDisplay} testid={testid} />;
+  return (
+    <OurTable data={finalsInfo} columns={columnsToDisplay} testid={testid} />
+  );
 }

--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
@@ -65,7 +65,7 @@ export default function CourseDetailsIndexPage() {
         quarterYYYYQ: qtr,
         enrollCd: enrollCode,
       },
-    }
+    },
   );
 
   return (

--- a/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
+++ b/frontend/src/main/pages/CourseDetails/CourseDetailsIndexPage.js
@@ -6,6 +6,7 @@ import CourseDetailsTable from "main/components/CourseDetails/CourseDetailsTable
 import { yyyyqToQyy } from "main/utils/quarterUtilities";
 import CourseDescriptionTable from "main/components/Courses/CourseDescriptionTable";
 import GradeHistoryGraphs from "main/components/GradeHistory/GradeHistoryGraph";
+import FinalsInfoDisplay from "main/components/CourseDetails/FinalsInfoDisplay";
 
 export default function CourseDetailsIndexPage() {
   // Stryker disable next-line all : Can't test state because hook is internal
@@ -54,6 +55,19 @@ export default function CourseDetailsIndexPage() {
     },
   );
 
+  // Fetch Finals Info
+  const { data: finalsInfo } = useBackend(
+    [`/api/public/finalsinfo?quarterYYYYQ=${qtr}&enrollCd=${enrollCode}`],
+    {
+      method: "GET",
+      url: `/api/public/finalsinfo`,
+      params: {
+        quarterYYYYQ: qtr,
+        enrollCd: enrollCode,
+      },
+    }
+  );
+
   return (
     <BasicLayout>
       <div className="pt-2">
@@ -66,6 +80,7 @@ export default function CourseDetailsIndexPage() {
         {moreDetails && <CourseDetailsTable details={[moreDetails]} />}
         {moreDetails && <CourseDescriptionTable course={moreDetails} />}
         {gradeHistory && <GradeHistoryGraphs gradeHistory={gradeHistory} />}
+        {finalsInfo && <FinalsInfoDisplay finalsInfo={[finalsInfo]} />}
       </div>
     </BasicLayout>
   );

--- a/frontend/src/stories/components/CourseDetails/FinalsInfoDisplay.stories.js
+++ b/frontend/src/stories/components/CourseDetails/FinalsInfoDisplay.stories.js
@@ -1,0 +1,23 @@
+import React from "react";
+
+import FinalsInfoDisplay from "main/components/CourseDetails/FinalsInfoDisplay";
+import { finalsInfoFixtures } from "fixtures/finalsInfoFixtures";
+
+export default {
+  title: "components/CourseDetails/FinalsInfoDisplay",
+  component: FinalsInfoDisplay,
+};
+
+const Template = (args) => {
+  return <FinalsInfoDisplay {...args} />;
+};
+
+export const Empty = Template.bind({});
+Empty.args = {
+  finalsInfo: [],
+};
+
+export const oneFinalsInfo = Template.bind({});
+oneFinalsInfo.args = {
+  finalsInfo: [finalsInfoFixtures.oneFinalsInfo],
+};

--- a/frontend/src/tests/components/CourseDetails/FinalsInfoDisplay.test.js
+++ b/frontend/src/tests/components/CourseDetails/FinalsInfoDisplay.test.js
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import FinalsInfoDisplay from "main/components/CourseDetails/FinalsInfoDisplay";
+import { finalsInfoFixtures } from "fixtures/finalsInfoFixtures";
+
+const mockedNavigate = jest.fn();
+
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useNavigate: () => mockedNavigate,
+}));
+
+const mockedMutate = jest.fn();
+
+jest.mock("main/utils/useBackend", () => ({
+  ...jest.requireActual("main/utils/useBackend"),
+  useBackendMutation: () => ({ mutate: mockedMutate }),
+}));
+
+describe("UserTable tests", () => {
+  const queryClient = new QueryClient();
+  test("renders without crashing for empty table", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <FinalsInfoDisplay finalsInfo={[]} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+  });
+
+  test("Has the expected colum headers and content", () => {
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <FinalsInfoDisplay
+            finalsInfo={[finalsInfoFixtures.oneFinalsInfo]}
+          />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+
+    const expectedHeaders = [
+      "Has Finals?",
+      "Comments",
+      "Exam Day",
+      "Exam Date",
+      "Begin Time",
+      "End Time",
+    ];
+    const expectedFields = [
+        "hasFinals",
+        "comments",
+        "examDay",
+        "examDate",
+        "beginTime",
+        "endTime",
+    ];
+
+    const testId = "FinalsInfoDisplay";
+
+    expectedHeaders.forEach((headerText) => {
+      const header = screen.getByText(headerText);
+      expect(header).toBeInTheDocument();
+    });
+
+    expectedFields.forEach((field) => {
+      const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
+      expect(header).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-hasFinals`),
+    ).toHaveTextContent("Yes");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-comments`),
+    ).toHaveTextContent("Final exam will be cumulative.");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-examDay`),
+    ).toHaveTextContent("R");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-examDate`),
+    ).toHaveTextContent("2022-06-09");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-beginTime`),
+    ).toHaveTextContent("08:00");
+    expect(
+      screen.getByTestId(`${testId}-cell-row-0-col-endTime`),
+    ).toHaveTextContent("11:00");
+  });
+});

--- a/frontend/src/tests/components/CourseDetails/FinalsInfoDisplay.test.js
+++ b/frontend/src/tests/components/CourseDetails/FinalsInfoDisplay.test.js
@@ -35,9 +35,7 @@ describe("UserTable tests", () => {
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <FinalsInfoDisplay
-            finalsInfo={[finalsInfoFixtures.oneFinalsInfo]}
-          />
+          <FinalsInfoDisplay finalsInfo={[finalsInfoFixtures.oneFinalsInfo]} />
         </MemoryRouter>
       </QueryClientProvider>,
     );
@@ -51,12 +49,12 @@ describe("UserTable tests", () => {
       "End Time",
     ];
     const expectedFields = [
-        "hasFinals",
-        "comments",
-        "examDay",
-        "examDate",
-        "beginTime",
-        "endTime",
+      "hasFinals",
+      "comments",
+      "examDay",
+      "examDate",
+      "beginTime",
+      "endTime",
     ];
 
     const testId = "FinalsInfoDisplay";


### PR DESCRIPTION
Closes #40 

When user clicks on "More info" button for a course, it takes the user to the Course Details Index Page. Below the Course Details table, there is now a table displaying information about the course's final exam such as date, start time, end time, etc.

dokku: https://proj-courses-nilay-kundu.dokku-04.cs.ucsb.edu

storybook: https://6734fd8a489da54c4e3feeff-mfmcmlppco.chromatic.com/?path=/story/components-coursedetails-finalsinfodisplay--one-finals-info